### PR TITLE
github: add .gitattributes (for syntax highlighting)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sol linguist-language=Solidity

--- a/contracts/test/TestToken.sol
+++ b/contracts/test/TestToken.sol
@@ -8,7 +8,7 @@ import "openzeppelin-solidity/contracts/math/SafeMath.sol";
  * @dev see https://github.com/ethereum/EIPs/issues/179
  */
 contract ERC20Basic {
-    /// Total amount of tokens
+    // Total amount of tokens
     uint256 public totalSupply;
   
     function balanceOf(address _owner) public view returns (uint256 balance);
@@ -39,7 +39,7 @@ contract ERC20 is ERC20Basic {
 contract BasicToken is ERC20Basic {
     using SafeMath for uint256;
 
-  //balance in each address account
+    // balance in each address account
     mapping(address => uint256) balances;
 
   /**
@@ -151,7 +151,7 @@ contract TestToken is StandardToken {
         symbol = tokenSymbol;
         balances[msg.sender] = totalSupply;
          
-         //Emitting transfer event since assigning all tokens to the creator also corresponds to the transfer of tokens to the creator
+        // Emitting transfer event since assigning all tokens to the creator also corresponds to the transfer of tokens to the creator
         emit Transfer(address(0), msg.sender, totalSupply);
     }
 }


### PR DESCRIPTION
... of `.sol` files, when viewed on GitHub's web interface.

I've used `TestToken.sol` to demonstrate, changing only comment lines (EDIT: well, and an EOF newline), so as not to introduce changes to the most important contracts.

The `.sol` files may require touching to become highlighted.

Compare:

* before (current `master`) - [`TestToken.sol`](https://github.com/OpenBazaar/smart-contracts/blob/cbce9ea38b04146fbdfd21567c7c63ccf3dee3eb/contracts/test/TestToken.sol);
* after (this PR) - [`TestToken.sol`](https://github.com/veox/smart-contracts/blob/47c90b0798e43ad68c5c035920bebc4af8ab0cf8/contracts/test/TestToken.sol).
